### PR TITLE
Discussion on the packaging of Python code

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -13,7 +13,6 @@
     * [setup.py](python/count_variants/setup_py.md)
     * [First module](python/count_variants/count_module.md)
     * [Installing](python/count_variants/installing.md)
-  	
 * [Perl](perl/README.md)
   * [Best Practices](perl/best_practises/best_practises.md)
     * [Identifiers](perl/best_practises/Identifiers.md)

--- a/python/count_variants/count_module.md
+++ b/python/count_variants/count_module.md
@@ -5,12 +5,13 @@ When we finnish this section we should have a small program that counts the numb
 We will try to keep the code separated inside our projekt as described [here](../conventions.md), we store the counting code in a submodule called utils and the cli code in a module called cli. So run:
 
 ```bash
-$ mkdir count_variants/cli count_variants/cli
-$ touch count_variants/cli/__init__.py
-$ touch count_variants/utils/__init__.py
-$ touch count_variants/cli/root.py
-$ touch count_variants/utils/count.py
+mkdir count_variants/cli count_variants/cli
+touch count_variants/cli/__init__.py
+touch count_variants/utils/__init__.py
+touch count_variants/cli/root.py
+touch count_variants/utils/count.py
 ```
+
 Ok a lot of files created here, the `__init__.py` files we know from before, they are there to tell that this is a module.
 `count_variants/cli/root.py` will include the command line interface to our program and `count_variants/utils/count.py` will include the code that counts vcf variants.
 
@@ -19,20 +20,19 @@ Ok a lot of files created here, the `__init__.py` files we know from before, the
 Open `count_variants/utils/count.py` and write the following
 
 ```python
-
 def count_variants(vcf):
     """Count the number of variants in a vcf file
-    
+
     Args:
         vcf(iterable): An iterable with variants
-    
+
     Returns:
         nr_variants(int): Number of variants in file
     """
     nr_variants = 0
     for variant in vcf:
         nr_variants += 1
-    
+
     return nr_variants
 
 ```
@@ -61,25 +61,26 @@ def cli(vcf):
     """Count the variants in a vcf"""
     coloredlogs.install(level='INFO')
     LOG.info("Reading vcf file: %s", vcf)
-    
+
     vcf_obj = VCF(vcf)
-    
+
     nr_variants = count_variants(vcf_obj)
-    
+
     click.echo("Nr variants in vcf: %s" % nr_variants)
 ```
 
 It is a good convention to import standard library modules first, then third party modules and finally local imports.
 
 In this case we will go through the code line by line.
+
  - `logging` is the standard library solution for logging in python.
- - `click` is our prefered package to buiild command line interfaces.
+ - `click` is our prefered package to build command line interfaces.
  - `coloredlogs` is a wrapper for `logging` that makes logging look good and super easy.
  - `cyvcf2` is a reliable and fast parser for VCF files
- - `count_variants.utils.count` on this line we import the function that we root in the previous section
+ - `count_variants.utils.count` on this line we import the function that we wrote in the previous section
  - `LOG = logging.getLogger(__name__)` here we create a logging object and name it `LOG`
  - `@click.command()` is a [decorator][decorators], you do not need to understand the concept right now. It basically give the following function some properties
- - `@click.argument()` this is how a argument is defined in click
+ - `@click.argument()` this is how an argument is defined in click
 
 Then comes the function definition, the docstring and some code that should be rather straight forward.
 
@@ -109,16 +110,13 @@ count_variants/
     ├── __init__.py
     ├── __version__.py
     ├── cli/
-    	├── __init__.py
-    	├── root.py
+        ├── __init__.py
+        ├── root.py
     ├── utils/
-    	├── __init__.py
-    	├── count.py
+        ├── __init__.py
+        ├── count.py
 ```
 
 If you haven't done so already, stage all the files and commit them!
-
-
-[previous(setup.py)](./setup_py.md)-[next(installing package)](installing.md)
 
 [decorators]: https://en.wikipedia.org/wiki/Python_syntax_and_semantics#Decorators

--- a/python/count_variants/installing.md
+++ b/python/count_variants/installing.md
@@ -1,8 +1,9 @@
 # Installing
 
-So it is time to install our package and see that everything works, exciting!
-There is only one thing missing, that is to tell `setup.py` how to use the command line interface that we wrote earlier.
-Open `setup.py` and look for `entry_points`, change that section to look like:
+So it is time to install our package and see that everything works, exciting! 😃
+
+There is only one thing missing; tell `setup.py` how to use the command line interface that we wrote earlier.
+Open `setup.py` and look for `entry_points` section. Change it to look like:
 
 ```python
     entry_points={
@@ -18,11 +19,12 @@ We are telling `setup.py` that if someone write `count_variants` on the command 
 
 Now we are going to run the command that installs all dependencies and the package itself:
 
-```
-$ python setup.py develop
+```bash
+pip install --editable .
 ```
 
-Watch the magic happen!
+Watch the magic happen! 🔮
+
 When you are done you should be able to write:
 
 ```bash
@@ -35,4 +37,4 @@ Error: Missing argument "vcf".
 Great job!!!
 If you have a vcf file lying around you could try and feed that to the program and see if it works.
 
-In the following sections we will add some complexity, write tests and push the code to github so others can see it.
+In the following sections we will add some complexity, write tests and push the code to GitHub so others can see it.

--- a/python/count_variants/overview.md
+++ b/python/count_variants/overview.md
@@ -1,8 +1,8 @@
 # Creating a Python package
 
-To be able to reuse code it is important to package the things we are doing in a way that makes them easy to install and operate.
-There are of course a number of ways to handle this situation and we will describe our prefered way to do it here.
-I will use an example as we go along, we are going to create a package called `count_variants` that is used to count variants with different selection criterias in a [VCF][vcf] file.
+To be able to reuse code it is important to package things we are doing in a way that makes them easy to install and operate.
+There are of course a number of ways to handle this and we will describe our prefered way to do it here.
+I will use an example as we go along; we are going to create a package called `count_variants` that is used to count variants with different selection criteria in a [VCF][vcf] file.
 
 In this example we will tie together many of the topics described in this guide, like [testing](../testing.md), [conventions](../conventions.md), [git](../../git/README.md), [logging](../logging.md) and perhaps some more.
 

--- a/python/count_variants/setup_py.md
+++ b/python/count_variants/setup_py.md
@@ -4,7 +4,7 @@ Every python package contains a special file called `setup.py ` in the root dire
 There is a excellent guide for how to setup a package and create the setup.py [here][setup_guide].
 Lets continue with our example following @kennethreitz guide, please read the guide first.
 
-Copy `setup.py` from the guide and open it, if you done it right it should look like
+Copy `setup.py` from the guide and open it, if you do it right it should look like:
 
 ```python
 #!/usr/bin/env python
@@ -269,13 +269,14 @@ From the [documentation][init_doc]
 > The __init__.py files are required to make Python treat the directories as containing packages; this is done to prevent directories with a common name, such as string, from unintentionally hiding valid modules that occur later (deeper) on the module search path. In the simplest case, __init__.py can just be an empty file, but it can also execute initialization code for the package or set the __all__ variable, described later.
 
 ```bash
-$ mkdir count_variants
-$ touch count_variants/__init__.py
-$ touch count_variants/__version__.py
+mkdir count_variants
+touch count_variants/__init__.py
+touch count_variants/__version__.py
 ```
+
 open `count_variants/__version__.py` and write:
 
-```
+```python
 __version__ = '0.1.0'
 ```
 
@@ -293,8 +294,7 @@ count_variants/
     ├── __version__.py
 ```
 
-Add all the new files to a new git commit.(Tips: use `git status` to see if all files are committed.) 
-
+Add all the new files to a new git commit. (Tip: use `git status` to see if all files are committed.)
 
 [setup_guide]: https://github.com/kennethreitz/setup.py
 [init_doc]: https://docs.python.org/3/tutorial/modules.html#packages

--- a/python/count_variants/structure.md
+++ b/python/count_variants/structure.md
@@ -6,16 +6,17 @@ Assuming you have conda installed, run the following:
 ## 1.1 Basics
 
 ```bash
-$ conda create -n count_variants python=3
-$ source activate count_variants
-$ mkdir count_variants
-$ cd count_variants
+conda create -n count_variants python=3
+source activate count_variants
+mkdir count_variants
+cd count_variants
 ```
+
 We wan't to do version handling with git, to make this a git repository do 
 
 ```bash
-$ git init
-$ touch .gitignore
+git init
+touch .gitignore
 ```
 
 The `.gitignore` file is explained in the [git section](../../git/README.md), for now we only need to know that this file tells git what to care and not care about. 
@@ -26,34 +27,37 @@ Every decent python package should at least include a README file that describes
 Let's create a `README.md` file, this will be updated as we go along. For now do
 
 ```bash
-$ touch README.md
+touch README.md
 ```
 
 open the file with an [editor](../../editors/README.md) of your choice and write the following:
 
-```
+```markdown
 # count_variants
 A package to count variants in VCF files based on different criterias.
 ```
 
+> You might recognize this as "markdown", a markup language for formatting text. You can read more about it under [Documentation](../../documentation/README.md).
+
 ## 1.3 LICENSE, MANIFEST.in, requirements.txt  {#license}
 
 Next step is to include a `LICENSE` file, every project should have one. There are many different licenses, you can read more [here][licenses]. For now we will choose a [MIT license][mit].
-Open a file called LICENSE and copy paste the MIT License and fill in year and name.
+Open a file called LICENSE and copy paste the [MIT License][mit] and fill in year and name.
 
 `MANIFEST.in` is a file that explains what non python static files should be included in the distribution. For now we will leave that one empty. Just do:
 
 ```bash
-$ touch MANIFEST.in
+touch MANIFEST.in
 ```
 
-`requirements.txt` is for explaining which third party software that our one is dependent on. Right now we only know that we will be using [click][click] to build a cli, so run:
+`requirements.txt` is for declaring which third party software our package depends on. Right now we only know that we will be using [Click][click] to build a cli, so run:
 
 ```bash
-$ echo click > requirements.txt
+echo click > requirements.txt
 ```
 
 ## 1.4 First commit {#first_commit}
+
 Save the changes. It is now time to do our first commit! Run:
 
 ```bash
@@ -72,18 +76,12 @@ Untracked files:
 	requirements.txt
 
 nothing added to commit but untracked files present (use "git add" to track)
-$ git add .gitignore
-$ git add README.md
-$ git add LICENSE
-$ git add MANIFEST.in
-$ git add requirements.txt
+$ git add .gitignore README.md LICENSE MANIFEST.in requirements.txt
 $ git commit -m "First commit"
 $ git status
 On branch master
 nothing to commit, working tree clean
 ```
-
-[previous(overview)](./overview.md) - [next(setup.py)](./setup_py.md)  
 
 [licenses]: https://help.github.com/articles/licensing-a-repository/
 [mit]: https://choosealicense.com/licenses/mit/


### PR DESCRIPTION
One conventions that is quite common in Python is to avoid using `_` (underscore) in module names. It's fine for variables etc. but when it's packages and modules I try to stick to single words or just concatenate them without separator: `count_variants` -> `countvariants` or perhaps something like `vcfcount` 🙂